### PR TITLE
feat(network): IPv6 interception and nftables support

### DIFF
--- a/internal/assets/apply-ip6tables.sh
+++ b/internal/assets/apply-ip6tables.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+set -e
+
+# Mirror of apply-iptables.sh, but for ip6tables
+# Usage: sh -s <MITM_PORT>
+
+MITM_PORT=${1:-18000}
+PROXY_MARK=${PROXY_MARK:-0x2000}
+
+ip6tables_cmd() {
+    ip6tables -w "$@"
+}
+
+ensure_rule() {
+    if ip6tables_cmd "$@" 2>/dev/null; then
+        return 0
+    fi
+    return 1
+}
+
+# Early returns to avoid loops and honor proxy mark
+if ! ensure_rule -t nat -C OUTPUT -p tcp --dport "$MITM_PORT" -j RETURN; then
+    ip6tables_cmd -t nat -I OUTPUT 1 -p tcp --dport "$MITM_PORT" -j RETURN
+fi
+
+if ! ensure_rule -t nat -C OUTPUT -m mark --mark "$PROXY_MARK" -j RETURN; then
+    ip6tables_cmd -t nat -I OUTPUT 2 -m mark --mark "$PROXY_MARK" -j RETURN
+fi
+
+# HTTP/HTTPS redirects over TCPv6
+if ! ensure_rule -t nat -C OUTPUT -p tcp --dport 80 -j REDIRECT --to-ports "$MITM_PORT"; then
+    ip6tables_cmd -t nat -A OUTPUT -p tcp --dport 80 -j REDIRECT --to-ports "$MITM_PORT"
+fi
+
+if ! ensure_rule -t nat -C OUTPUT -p tcp --dport 443 -j REDIRECT --to-ports "$MITM_PORT"; then
+    ip6tables_cmd -t nat -A OUTPUT -p tcp --dport 443 -j REDIRECT --to-ports "$MITM_PORT"
+fi
+
+# Kill QUIC over IPv6 to force TLS over TCP through the MITM
+if ! ensure_rule -t mangle -C OUTPUT -p udp --dport 443 -j DROP; then
+    ip6tables_cmd -t mangle -A OUTPUT -p udp --dport 443 -j DROP
+fi
+

--- a/internal/assets/apply-nftables.sh
+++ b/internal/assets/apply-nftables.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+set -e
+
+# Apply nftables rules for both IPv4 and IPv6 with idempotency.
+# - NAT OUTPUT redirect for tcp/{80,443} to MITM_PORT
+# - Early return for MITM_PORT and PROXY_MARK to avoid loops
+# - Drop QUIC (udp/443) via inet route hook
+
+MITM_PORT=${1:-18000}
+PROXY_MARK=${PROXY_MARK:-0x2000}
+NFT=${NFT:-nft}
+
+nft_cmd() {
+    "$NFT" "$@"
+}
+
+ensure_table() {
+    fam=$1; tbl=$2
+    if ! nft_cmd list table "$fam" "$tbl" >/dev/null 2>&1; then
+        nft_cmd add table "$fam" "$tbl"
+    fi
+}
+
+ensure_chain() {
+    fam=$1; tbl=$2; chain=$3; shift 3
+    # Remaining args are chain definition words, e.g. { type nat hook output priority -100; }
+    if ! nft_cmd list chain "$fam" "$tbl" "$chain" >/dev/null 2>&1; then
+        nft_cmd add chain "$fam" "$tbl" "$chain" "$@"
+    fi
+}
+
+ensure_rule() {
+    fam=$1; tbl=$2; chain=$3; shift 3
+    comment=$1; shift 1
+    # Remaining args are rule words
+    if nft_cmd list chain "$fam" "$tbl" "$chain" 2>/dev/null | grep -F "comment \"$comment\"" >/dev/null; then
+        return 0
+    fi
+    nft_cmd add rule "$fam" "$tbl" "$chain" "$@" comment "$comment"
+}
+
+# IPv4 NAT OUTPUT
+ensure_table ip leash
+ensure_chain ip leash out_nat { type nat hook output priority -100\; }
+ensure_rule ip leash out_nat "leash:return-mitm" tcp dport $MITM_PORT return
+ensure_rule ip leash out_nat "leash:return-mark" meta mark $PROXY_MARK return
+ensure_rule ip leash out_nat "leash:redir-80-443" tcp dport {80,443} redirect to :$MITM_PORT
+
+# IPv6 NAT OUTPUT
+ensure_table ip6 leash6
+ensure_chain ip6 leash6 out_nat { type nat hook output priority -100\; }
+ensure_rule ip6 leash6 out_nat "leash:return-mitm" tcp dport $MITM_PORT return
+ensure_rule ip6 leash6 out_nat "leash:return-mark" meta mark $PROXY_MARK return
+ensure_rule ip6 leash6 out_nat "leash:redir-80-443" tcp dport {80,443} redirect to :$MITM_PORT
+
+# inet route hook to drop QUIC for both families
+ensure_table inet leash
+ensure_chain inet leash out_route { type route hook output priority 0\; }
+ensure_rule inet leash out_route "leash:drop-quic" udp dport 443 drop
+

--- a/internal/assets/scripts.go
+++ b/internal/assets/scripts.go
@@ -5,5 +5,11 @@ import _ "embed"
 //go:embed apply-iptables.sh
 var ApplyIptablesScript string
 
+//go:embed apply-ip6tables.sh
+var ApplyIp6tablesScript string
+
+//go:embed apply-nftables.sh
+var ApplyNftablesScript string
+
 //go:embed leash_prompt.sh
 var LeashPromptScript string


### PR DESCRIPTION
- Add apply-ip6tables.sh to configure TCPv6 redirect for 80/443, early-return on MITM port and PROXY_MARK, and drop QUIC (udp/443).
- Add apply-nftables.sh with idempotent rules covering IPv4+IPv6: NAT OUTPUT redirect to MITM_PORT, early returns for MITM_PORT and PROXY_MARK, and drop QUIC using inet route hook.

Runtime:
- Prefer nftables when available, otherwise fall back to iptables and best-effort ip6tables; continue to work if nft/ip6tables are missing.
- Embed and execute the new scripts; add helpers to locate binaries.
- Log clearer message when applying network interception rules.

Proxy:
- Make TLS SNI/hostname parsing IPv6-aware (handle [addr]:port).
- Retrieve original destination for IPv4 (SO_ORIGINAL_DST) and IPv6 (IP6T_SO_ORIGINAL_DST), returning bracketed host:port for v6.

Assets:
- Embed apply-ip6tables.sh and apply-nftables.sh in scripts.go.

Behavioral notes:
- Redirects only affect locally-originated TCP traffic; UDP/443 is dropped to force TLS over TCP through the MITM.
- No change in behavior on hosts without nft/ip6tables.