### PR TITLE
test(flakes): ensure runtime env cleanup removes base dir

### DIFF
--- a/internal/leashd/runtime_private_dir_test.go
+++ b/internal/leashd/runtime_private_dir_test.go
@@ -138,6 +138,9 @@ func setupRuntimeEnv(t *testing.T, includeBadKey bool) (*runtimeConfig, func()) 
 		} else {
 			_ = os.Unsetenv("LEASH_DIR")
 		}
+		if err := os.RemoveAll(base); err != nil {
+			t.Fatalf("cleanup runtime env: %v", err)
+		}
 		privateDirMu.Unlock()
 	}
 	return cfg, cleanup


### PR DESCRIPTION
Resolves intermittent "directory not empty" failure when preFlight writes policy artifacts (runtime_private_dir_test.go:130-144).