### PR TITLE
Add missing base image to Dockerfile example 🧱

### DIFF
--- a/docs/CUSTOM-DOCKER-IMAGES.md
+++ b/docs/CUSTOM-DOCKER-IMAGES.md
@@ -32,6 +32,8 @@ apk add --no-cache ca-certificates
 ```Dockerfile
 FROM public.ecr.aws/s5i7k8t3/strongdm/leash:latest AS leash
 
+FROM public.ecr.aws/s5i7k8t3/strongdm/coder:latest
+
 # ... your existing build stages ...
 
 # Install any additional packages you need (example)


### PR DESCRIPTION
The example Dockerfile was missing the base image declaration. Added the coder base image after the leash stage to complete the example.