### PR TITLE
Forbid target container from communicating with control plane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.dev-docker-*
 *.o
 *.tmp
+*.test
 
 # go:generate'd resources
 /internal/entrypoint/embed/*

--- a/internal/assets/apply-ip6tables.sh
+++ b/internal/assets/apply-ip6tables.sh
@@ -1,11 +1,17 @@
 #!/bin/sh
-set -e
-
 # Mirror of apply-iptables.sh, but for ip6tables
-# Usage: sh -s <MITM_PORT>
+# Usage: sh -s <MITM_PORT> [LEASH_PORT] [TARGET_CGROUP]
+#
+# NOTE: We intentionally do NOT use set -e here. Each rule is applied
+# individually with error handling to provide better diagnostics and
+# allow partial functionality when some ip6tables features aren't available.
 
 MITM_PORT=${1:-18000}
+LEASH_PORT=${2:-}
+TARGET_CGROUP=${3:-}
 PROXY_MARK=${PROXY_MARK:-0x2000}
+
+RULE_ERRORS=0
 
 ip6tables_cmd() {
     ip6tables -w "$@"
@@ -18,26 +24,59 @@ ensure_rule() {
     return 1
 }
 
+# Helper to apply a rule with error handling
+apply_rule() {
+    desc="$1"; shift
+    if ! "$@" 2>/dev/null; then
+        echo "leash: WARNING: failed to apply ip6tables rule: $desc" >&2
+        RULE_ERRORS=$((RULE_ERRORS + 1))
+        return 1
+    fi
+    return 0
+}
+
 # Early returns to avoid loops and honor proxy mark
 if ! ensure_rule -t nat -C OUTPUT -p tcp --dport "$MITM_PORT" -j RETURN; then
-    ip6tables_cmd -t nat -I OUTPUT 1 -p tcp --dport "$MITM_PORT" -j RETURN
+    apply_rule "nat OUTPUT return for MITM port" ip6tables_cmd -t nat -I OUTPUT 1 -p tcp --dport "$MITM_PORT" -j RETURN
 fi
 
 if ! ensure_rule -t nat -C OUTPUT -m mark --mark "$PROXY_MARK" -j RETURN; then
-    ip6tables_cmd -t nat -I OUTPUT 2 -m mark --mark "$PROXY_MARK" -j RETURN
+    apply_rule "nat OUTPUT return for proxy mark" ip6tables_cmd -t nat -I OUTPUT 2 -m mark --mark "$PROXY_MARK" -j RETURN
 fi
 
 # HTTP/HTTPS redirects over TCPv6
 if ! ensure_rule -t nat -C OUTPUT -p tcp --dport 80 -j REDIRECT --to-ports "$MITM_PORT"; then
-    ip6tables_cmd -t nat -A OUTPUT -p tcp --dport 80 -j REDIRECT --to-ports "$MITM_PORT"
+    apply_rule "nat OUTPUT redirect HTTP" ip6tables_cmd -t nat -A OUTPUT -p tcp --dport 80 -j REDIRECT --to-ports "$MITM_PORT"
 fi
 
 if ! ensure_rule -t nat -C OUTPUT -p tcp --dport 443 -j REDIRECT --to-ports "$MITM_PORT"; then
-    ip6tables_cmd -t nat -A OUTPUT -p tcp --dport 443 -j REDIRECT --to-ports "$MITM_PORT"
+    apply_rule "nat OUTPUT redirect HTTPS" ip6tables_cmd -t nat -A OUTPUT -p tcp --dport 443 -j REDIRECT --to-ports "$MITM_PORT"
 fi
 
 # Kill QUIC over IPv6 to force TLS over TCP through the MITM
 if ! ensure_rule -t mangle -C OUTPUT -p udp --dport 443 -j DROP; then
-    ip6tables_cmd -t mangle -A OUTPUT -p udp --dport 443 -j DROP
+    apply_rule "mangle OUTPUT drop QUIC" ip6tables_cmd -t mangle -A OUTPUT -p udp --dport 443 -j DROP
 fi
+
+# Block target container from reaching leashd control plane on any interface (IPv6).
+# This prevents a compromised agent from accessing the leashd API.
+# SECURITY: This is a REQUIRED security control - failure is fatal.
+# Requires --cgroupns=host on the container to see host cgroup paths.
+if [ -n "$TARGET_CGROUP" ] && [ -n "$LEASH_PORT" ]; then
+    if ! ensure_rule -t filter -C OUTPUT -m cgroup --path "$TARGET_CGROUP" -p tcp --dport "$LEASH_PORT" -j REJECT; then
+        if ip6tables_cmd -t filter -A OUTPUT -m cgroup --path "$TARGET_CGROUP" -p tcp --dport "$LEASH_PORT" -j REJECT --reject-with tcp-reset 2>&1; then
+            echo "leash: blocked target cgroup $TARGET_CGROUP from reaching control plane port $LEASH_PORT (ip6tables)"
+        else
+            echo "leash: FATAL: could not apply cgroup-based control plane isolation (IPv6)" >&2
+            echo "leash: This security control is required to prevent target container from accessing leashd API" >&2
+            exit 1
+        fi
+    fi
+fi
+
+# Report summary and exit successfully even if some rules failed
+if [ "$RULE_ERRORS" -gt 0 ]; then
+    echo "leash: WARNING: $RULE_ERRORS ip6tables rule(s) failed to apply (IPv6 network interception may be incomplete)" >&2
+fi
+exit 0
 

--- a/internal/assets/apply-iptables.sh
+++ b/internal/assets/apply-iptables.sh
@@ -1,8 +1,14 @@
 #!/bin/sh
-set -e
+# NOTE: We intentionally do NOT use set -e here. Each rule is applied
+# individually with error handling to provide better diagnostics and
+# allow partial functionality when some iptables features aren't available.
 
 MITM_PORT=${1:-18000}
+LEASH_PORT=${2:-}
+TARGET_CGROUP=${3:-}
 PROXY_MARK=${PROXY_MARK:-0x2000}
+
+RULE_ERRORS=0
 
 iptables_cmd() {
     iptables -w "$@"
@@ -15,22 +21,61 @@ ensure_rule() {
     return 1
 }
 
+# Helper to apply a rule with error handling
+apply_rule() {
+    desc="$1"; shift
+    if ! "$@" 2>/dev/null; then
+        echo "leash: WARNING: failed to apply iptables rule: $desc" >&2
+        RULE_ERRORS=$((RULE_ERRORS + 1))
+        return 1
+    fi
+    return 0
+}
+
+# Early return for MITM port to avoid loops
 if ! ensure_rule -t nat -C OUTPUT -p tcp --dport "$MITM_PORT" -j RETURN; then
-    iptables_cmd -t nat -I OUTPUT 1 -p tcp --dport "$MITM_PORT" -j RETURN
+    apply_rule "nat OUTPUT return for MITM port" iptables_cmd -t nat -I OUTPUT 1 -p tcp --dport "$MITM_PORT" -j RETURN
 fi
 
+# Early return for marked packets to avoid loops
 if ! ensure_rule -t nat -C OUTPUT -m mark --mark "$PROXY_MARK" -j RETURN; then
-    iptables_cmd -t nat -I OUTPUT 2 -m mark --mark "$PROXY_MARK" -j RETURN
+    apply_rule "nat OUTPUT return for proxy mark" iptables_cmd -t nat -I OUTPUT 2 -m mark --mark "$PROXY_MARK" -j RETURN
 fi
 
+# Redirect HTTP to MITM proxy
 if ! ensure_rule -t nat -C OUTPUT -p tcp --dport 80 -j REDIRECT --to-ports "$MITM_PORT"; then
-    iptables_cmd -t nat -A OUTPUT -p tcp --dport 80 -j REDIRECT --to-ports "$MITM_PORT"
+    apply_rule "nat OUTPUT redirect HTTP" iptables_cmd -t nat -A OUTPUT -p tcp --dport 80 -j REDIRECT --to-ports "$MITM_PORT"
 fi
 
+# Redirect HTTPS to MITM proxy
 if ! ensure_rule -t nat -C OUTPUT -p tcp --dport 443 -j REDIRECT --to-ports "$MITM_PORT"; then
-    iptables_cmd -t nat -A OUTPUT -p tcp --dport 443 -j REDIRECT --to-ports "$MITM_PORT"
+    apply_rule "nat OUTPUT redirect HTTPS" iptables_cmd -t nat -A OUTPUT -p tcp --dport 443 -j REDIRECT --to-ports "$MITM_PORT"
 fi
 
+# Drop QUIC to force TLS over TCP through the MITM
 if ! ensure_rule -t mangle -C OUTPUT -p udp --dport 443 -j DROP; then
-    iptables_cmd -t mangle -A OUTPUT -p udp --dport 443 -j DROP
+    apply_rule "mangle OUTPUT drop QUIC" iptables_cmd -t mangle -A OUTPUT -p udp --dport 443 -j DROP
 fi
+
+# Block target container from reaching leashd control plane on any interface.
+# This prevents a compromised agent from accessing the leashd API.
+# SECURITY: This is a REQUIRED security control - failure is fatal.
+# Requires --cgroupns=host on the container to see host cgroup paths.
+if [ -n "$TARGET_CGROUP" ] && [ -n "$LEASH_PORT" ]; then
+    if ! ensure_rule -t filter -C OUTPUT -m cgroup --path "$TARGET_CGROUP" -p tcp --dport "$LEASH_PORT" -j REJECT; then
+        if iptables_cmd -t filter -A OUTPUT -m cgroup --path "$TARGET_CGROUP" -p tcp --dport "$LEASH_PORT" -j REJECT --reject-with tcp-reset 2>&1; then
+            echo "leash: blocked target cgroup $TARGET_CGROUP from reaching control plane port $LEASH_PORT"
+        else
+            echo "leash: FATAL: could not apply cgroup-based control plane isolation" >&2
+            echo "leash: This security control is required to prevent target container from accessing leashd API" >&2
+            exit 1
+        fi
+    fi
+fi
+
+# Report summary and exit successfully even if some rules failed
+# (we log warnings above for failed rules)
+if [ "$RULE_ERRORS" -gt 0 ]; then
+    echo "leash: WARNING: $RULE_ERRORS iptables rule(s) failed to apply (network interception may be incomplete)" >&2
+fi
+exit 0

--- a/internal/assets/apply-nftables.sh
+++ b/internal/assets/apply-nftables.sh
@@ -1,14 +1,21 @@
 #!/bin/sh
-set -e
-
 # Apply nftables rules for both IPv4 and IPv6 with idempotency.
 # - NAT OUTPUT redirect for tcp/{80,443} to MITM_PORT
 # - Early return for MITM_PORT and PROXY_MARK to avoid loops
 # - Drop QUIC (udp/443) via inet route hook
+# - Block target cgroup from reaching leashd control plane
+#
+# NOTE: We intentionally do NOT use set -e here. Each rule is applied
+# individually with error handling to provide better diagnostics and
+# allow partial functionality when some nftables features aren't available.
 
 MITM_PORT=${1:-18000}
+LEASH_PORT=${2:-}
+TARGET_CGROUP=${3:-}
 PROXY_MARK=${PROXY_MARK:-0x2000}
 NFT=${NFT:-nft}
+
+RULE_ERRORS=0
 
 nft_cmd() {
     "$NFT" "$@"
@@ -17,16 +24,26 @@ nft_cmd() {
 ensure_table() {
     fam=$1; tbl=$2
     if ! nft_cmd list table "$fam" "$tbl" >/dev/null 2>&1; then
-        nft_cmd add table "$fam" "$tbl"
+        if ! nft_cmd add table "$fam" "$tbl" 2>/dev/null; then
+            echo "leash: WARNING: failed to create nftables table $fam $tbl" >&2
+            RULE_ERRORS=$((RULE_ERRORS + 1))
+            return 1
+        fi
     fi
+    return 0
 }
 
 ensure_chain() {
     fam=$1; tbl=$2; chain=$3; shift 3
     # Remaining args are chain definition words, e.g. { type nat hook output priority -100; }
     if ! nft_cmd list chain "$fam" "$tbl" "$chain" >/dev/null 2>&1; then
-        nft_cmd add chain "$fam" "$tbl" "$chain" "$@"
+        if ! nft_cmd add chain "$fam" "$tbl" "$chain" "$@" 2>/dev/null; then
+            echo "leash: WARNING: failed to create nftables chain $fam $tbl $chain" >&2
+            RULE_ERRORS=$((RULE_ERRORS + 1))
+            return 1
+        fi
     fi
+    return 0
 }
 
 ensure_rule() {
@@ -36,7 +53,12 @@ ensure_rule() {
     if nft_cmd list chain "$fam" "$tbl" "$chain" 2>/dev/null | grep -F "comment \"$comment\"" >/dev/null; then
         return 0
     fi
-    nft_cmd add rule "$fam" "$tbl" "$chain" "$@" comment "$comment"
+    if ! nft_cmd add rule "$fam" "$tbl" "$chain" "$@" comment "$comment" 2>/dev/null; then
+        echo "leash: WARNING: failed to add nftables rule $comment" >&2
+        RULE_ERRORS=$((RULE_ERRORS + 1))
+        return 1
+    fi
+    return 0
 }
 
 # IPv4 NAT OUTPUT
@@ -57,4 +79,29 @@ ensure_rule ip6 leash6 out_nat "leash:redir-80-443" tcp dport {80,443} redirect 
 ensure_table inet leash
 ensure_chain inet leash out_route { type route hook output priority 0\; }
 ensure_rule inet leash out_route "leash:drop-quic" udp dport 443 drop
+
+# Block target cgroup from reaching leashd control plane on any interface.
+# This prevents a compromised agent from accessing the leashd API.
+# Uses inet family to cover both IPv4 and IPv6.
+# SECURITY: This is a REQUIRED security control - failure is fatal.
+# Requires --cgroupns=host on the container to see host cgroup paths.
+if [ -n "$TARGET_CGROUP" ] && [ -n "$LEASH_PORT" ]; then
+    ensure_chain inet leash out_filter { type filter hook output priority 0\; }
+    # Check if rule already exists
+    if nft_cmd list chain inet leash out_filter 2>/dev/null | grep -F "leash:block-control-plane" >/dev/null; then
+        : # Rule already exists, nothing to do
+    elif nft_cmd add rule inet leash out_filter socket cgroupv2 level 1 "$TARGET_CGROUP" tcp dport $LEASH_PORT reject with tcp reset comment "leash:block-control-plane" 2>&1; then
+        echo "leash: blocked target cgroup $TARGET_CGROUP from reaching control plane port $LEASH_PORT (nftables)"
+    else
+        echo "leash: FATAL: could not apply cgroup-based control plane isolation (nftables)" >&2
+        echo "leash: This security control is required to prevent target container from accessing leashd API" >&2
+        exit 1
+    fi
+fi
+
+# Report summary and exit successfully even if some rules failed
+if [ "$RULE_ERRORS" -gt 0 ]; then
+    echo "leash: WARNING: $RULE_ERRORS nftables rule(s) failed to apply (network interception may be incomplete)" >&2
+fi
+exit 0
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -2023,6 +2023,7 @@ func (r *runner) launchLeashContainer(ctx context.Context, cgroupPath string) er
 		"--name", r.cfg.leashContainer,
 		"--privileged",
 		"--cap-add", "NET_ADMIN",
+		"--cgroupns=host", // Use host cgroup namespace for iptables cgroup matching
 		"--network", fmt.Sprintf("container:%s", r.cfg.targetContainer),
 		"-v", "/sys/fs/cgroup:/sys/fs/cgroup:ro",
 		"-v", fmt.Sprintf("%s:/log", r.cfg.logDir),


### PR DESCRIPTION
fix(security): block target container from reaching leashd control plane API

This change blocks the target container from reaching the leashd control
plane API. Previously, a process running inside the target container could
potentially connect to leashd's HTTP API (default port 18080) and interact
with the control plane. This is a security boundary violation - a
compromised AI agent should not be able to access the policy management API.

How it works:
The iptables/nftables rule matches packets originating from the target
container's cgroup and destined for the leashd control port, then rejects
them with TCP reset. This blocks all interfaces (localhost, LAN, etc.)
since the rule targets the port regardless of destination IP.

Files changed:
- internal/assets/apply-iptables.sh: Added iptables rule using cgroup
  matching to block target container from leashd port
- internal/assets/apply-nftables.sh: Added equivalent nftables rule for
  systems using nftables
- internal/assets/apply-ip6tables.sh: Added IPv6 equivalent rule
- internal/leashd/runtime.go: Updated to pass leashd port and cgroup path
  to the firewall scripts
- e2e/integration/integration_test.go: Added integration test
  'baseline/control-plane-isolation' to prevent regressions

Addresses and resolves [GHSA-9x85-c42x-79cx](https://github.com/strongdm/leash/security/advisories/GHSA-9x85-c42x-79cx).