### PR TITLE
fix: stabilize leash monitor UI and cgroup firewall handling

### DIFF
--- a/Dockerfile.coder
+++ b/Dockerfile.coder
@@ -2,6 +2,7 @@ FROM debian:testing-slim
 
 ARG NODE_MAJOR=22
 ENV DEBIAN_FRONTEND=noninteractive
+ENV NODE_OPTIONS="--dns-result-order=ipv4first"
 
 ARG VERSION=dev
 ARG COMMIT=dev
@@ -29,6 +30,7 @@ RUN set -eux; \
         opencode-ai@latest; \
     npm install -g \
         @upstash/context7-mcp; \
+    printf 'precedence ::ffff:0:0/96 100\n' >> /etc/gai.conf; \
     rm -rf /var/lib/apt/lists/*
 
 LABEL org.opencontainers.image.version="v${VERSION}" \

--- a/internal/leashd/listen/listen.go
+++ b/internal/leashd/listen/listen.go
@@ -84,6 +84,16 @@ func (c Config) Address() string {
 	return net.JoinHostPort(c.Host, c.Port)
 }
 
+// ContainerAddress returns the bind string used inside the container network namespace.
+// We always bind wildcard in-container and rely on Docker host publish rules to restrict
+// host-side exposure (for example, 127.0.0.1-only).
+func (c Config) ContainerAddress() string {
+	if c.Disable {
+		return ""
+	}
+	return ":" + c.Port
+}
+
 // DockerPublish returns the docker -p argument for this listen configuration.
 func (c Config) DockerPublish() string {
 	if c.Disable {

--- a/internal/leashd/listen/listen_test.go
+++ b/internal/leashd/listen/listen_test.go
@@ -88,3 +88,17 @@ func TestDisplayURL(t *testing.T) {
 		t.Fatalf("DisplayURL ipv6 = %s", got)
 	}
 }
+
+func TestContainerAddress(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{Host: "127.0.0.1", Port: "18080"}
+	if got := cfg.ContainerAddress(); got != ":18080" {
+		t.Fatalf("ContainerAddress loopback = %s", got)
+	}
+
+	disabled := Config{Disable: true}
+	if got := disabled.ContainerAddress(); got != "" {
+		t.Fatalf("ContainerAddress disabled = %q", got)
+	}
+}

--- a/internal/leashd/runtime.go
+++ b/internal/leashd/runtime.go
@@ -643,8 +643,10 @@ func (rt *runtimeState) configureNetwork() error {
 		}
 	}
 
+	// iptables --path and nft socket cgroupv2 expect paths relative to cgroup2 root.
+	cgroupPathForFirewall := normalizeCgroupPathForFirewall(rt.cfg.CgroupPath)
 	fmt.Fprintf(os.Stderr, "leash: applying network interception rules\n")
-	if err := applyNetworkRules(rt.cfg.ProxyPort, leashPort, rt.cfg.CgroupPath); err != nil {
+	if err := applyNetworkRules(rt.cfg.ProxyPort, leashPort, cgroupPathForFirewall); err != nil {
 		return err
 	}
 
@@ -676,6 +678,23 @@ func (rt *runtimeState) configureNetwork() error {
 		log.Printf("Warning: Failed to mount tracefs: %v", err)
 	}
 	return nil
+}
+
+func normalizeCgroupPathForFirewall(path string) string {
+	cleaned := filepath.Clean(strings.TrimSpace(path))
+	if cleaned == "" {
+		return ""
+	}
+
+	const cgroupRoot = "/sys/fs/cgroup"
+	switch {
+	case cleaned == cgroupRoot:
+		return "/"
+	case strings.HasPrefix(cleaned, cgroupRoot+"/"):
+		return strings.TrimPrefix(cleaned, cgroupRoot+"/")
+	default:
+		return cleaned
+	}
 }
 
 func connectDefaultAllow(policies *lsm.PolicySet) bool {

--- a/internal/leashd/runtime_test.go
+++ b/internal/leashd/runtime_test.go
@@ -431,3 +431,45 @@ func TestPreFlightMissingIptables(t *testing.T) {
 		t.Fatalf("expected iptables error, got %v", err)
 	}
 }
+
+func TestNormalizeCgroupPathForFirewall(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "absolute path under cgroup root",
+			in:   "/sys/fs/cgroup/system.slice/docker-abc.scope",
+			want: "system.slice/docker-abc.scope",
+		},
+		{
+			name: "cgroup root only",
+			in:   "/sys/fs/cgroup",
+			want: "/",
+		},
+		{
+			name: "already relative",
+			in:   "system.slice/docker-abc.scope",
+			want: "system.slice/docker-abc.scope",
+		},
+		{
+			name: "other absolute path unchanged",
+			in:   "/tmp/custom-cgroup",
+			want: "/tmp/custom-cgroup",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := normalizeCgroupPathForFirewall(tc.in)
+			if got != tc.want {
+				t.Fatalf("normalizeCgroupPathForFirewall(%q) = %q; want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -2099,7 +2099,7 @@ func (r *runner) launchLeashContainer(ctx context.Context, cgroupPath string) er
 		"-v", r.internalBindMountSpec(r.cfg.shareDir, leashPublicMount, ""),
 		"-v", r.internalBindMountSpec(r.cfg.privateDir, leashPrivateMount, ""),
 		"-e", fmt.Sprintf("LEASH_PROXY_PORT=%s", r.cfg.proxyPort),
-		"-e", fmt.Sprintf("LEASH_LISTEN=%s", r.cfg.listenCfg.Address()),
+		"-e", fmt.Sprintf("LEASH_LISTEN=%s", r.cfg.listenCfg.ContainerAddress()),
 		"-e", "LEASH_LOG=/log/events.log",
 		"-e", "LEASH_POLICY=/cfg/leash.cedar",
 		"-e", fmt.Sprintf("LEASH_CGROUP_PATH=%s", cgroupPath),
@@ -2110,7 +2110,7 @@ func (r *runner) launchLeashContainer(ctx context.Context, cgroupPath string) er
 	leashMounts := []string{"/sys/fs/cgroup", "/log", "/cfg", leashPublicMount, leashPrivateMount}
 	leashEnv := []string{
 		fmt.Sprintf("LEASH_PROXY_PORT=%s", r.cfg.proxyPort),
-		fmt.Sprintf("LEASH_LISTEN=%s", r.cfg.listenCfg.Address()),
+		fmt.Sprintf("LEASH_LISTEN=%s", r.cfg.listenCfg.ContainerAddress()),
 		"LEASH_LOG=/log/events.log",
 		"LEASH_POLICY=/cfg/leash.cedar",
 		fmt.Sprintf("LEASH_CGROUP_PATH=%s", cgroupPath),


### PR DESCRIPTION
## Summary
- normalize cgroup path before iptables cgroup matching in leashd
- bind control UI on container wildcard address while preserving host-side publish IP restrictions
- add listen coverage for container bind behavior

## Validation
- go test ./internal/leashd/listen
- smoke-tested codex/claude/opencode monitored launches via leash wrappers
- verified control UI returns HTTP 200 on localhost during monitored session