### PR TITLE
fix(leashd): degrade to proxy-only enforcement when cgroup path unavailable

### DIFF
--- a/cmd/leash-entry/main.go
+++ b/cmd/leash-entry/main.go
@@ -252,7 +252,13 @@ func emitCgroupPath() error {
 	}
 
 	if resolved == "" {
-		return fmt.Errorf("cgroup path not detected; ensure container runs with --cgroupns host")
+		// Some environments (notably Docker Desktop with Kubernetes) run the
+		// container in a private cgroup namespace where /proc/self/cgroup reports
+		// "0::/", leaving no scopable cgroup. Rather than aborting the container,
+		// continue without writing cgroup-path: leashd degrades to proxy-only
+		// enforcement (kernel LSM disabled, L7 proxy still active). See issue #67.
+		os.Stderr.WriteString("leash-entry: WARNING: no scopable cgroup in /proc/self/cgroup (e.g. Docker Desktop Kubernetes); continuing without cgroup scoping — kernel LSM enforcement disabled, proxy enforcement remains active\n")
+		return nil
 	}
 
 	if err := os.WriteFile(cgroupPathFile, []byte(resolved+"\n"), 0o644); err != nil {

--- a/internal/assets/apply-ip6tables.sh
+++ b/internal/assets/apply-ip6tables.sh
@@ -86,6 +86,22 @@ if [ -n "$TARGET_CGROUP" ] && [ -n "$LEASH_PORT" ]; then
     fi
 fi
 
+# Degraded mode (#67): no target cgroup (e.g. Docker Desktop Kubernetes private
+# cgroup namespace). The control plane must still be isolated, so block ALL local
+# access to the port — the same namespace-wide boundary as the cgroup fallback above.
+if [ -z "$TARGET_CGROUP" ] && [ -n "$LEASH_PORT" ]; then
+    echo "leash: WARNING: no target cgroup (degraded mode); blocking all local access to control plane port $LEASH_PORT (IPv6)" >&2
+    if ! ensure_rule -t filter -C OUTPUT -p tcp --dport "$LEASH_PORT" -j REJECT --reject-with tcp-reset; then
+        if ip6tables_cmd -t filter -A OUTPUT -p tcp --dport "$LEASH_PORT" -j REJECT --reject-with tcp-reset 2>&1; then
+            echo "leash: blocked local access to control plane port $LEASH_PORT (degraded, no cgroup, IPv6)"
+        else
+            echo "leash: FATAL: could not apply control plane isolation (degraded mode, IPv6)" >&2
+            echo "leash: This security control is required to prevent target container from accessing leashd API" >&2
+            exit 1
+        fi
+    fi
+fi
+
 # Report summary and exit successfully even if some rules failed
 if [ "$RULE_ERRORS" -gt 0 ]; then
     echo "leash: WARNING: $RULE_ERRORS ip6tables rule(s) failed to apply (IPv6 network interception may be incomplete)" >&2

--- a/internal/assets/apply-iptables.sh
+++ b/internal/assets/apply-iptables.sh
@@ -85,6 +85,23 @@ if [ -n "$TARGET_CGROUP" ] && [ -n "$LEASH_PORT" ]; then
     fi
 fi
 
+# Degraded mode (#67): no target cgroup (e.g. Docker Desktop Kubernetes private
+# cgroup namespace, where /proc/self/cgroup is "0::/"). The control plane must
+# still be isolated, so block ALL local access to the port — the same
+# namespace-wide boundary as the cgroup fallback above.
+if [ -z "$TARGET_CGROUP" ] && [ -n "$LEASH_PORT" ]; then
+    echo "leash: WARNING: no target cgroup (degraded mode); blocking all local access to control plane port $LEASH_PORT" >&2
+    if ! ensure_rule -t filter -C OUTPUT -p tcp --dport "$LEASH_PORT" -j REJECT --reject-with tcp-reset; then
+        if iptables_cmd -t filter -A OUTPUT -p tcp --dport "$LEASH_PORT" -j REJECT --reject-with tcp-reset 2>&1; then
+            echo "leash: blocked local access to control plane port $LEASH_PORT (degraded, no cgroup)"
+        else
+            echo "leash: FATAL: could not apply control plane isolation (degraded mode)" >&2
+            echo "leash: This security control is required to prevent target container from accessing leashd API" >&2
+            exit 1
+        fi
+    fi
+fi
+
 # Report summary and exit successfully even if some rules failed
 # (we log warnings above for failed rules)
 if [ "$RULE_ERRORS" -gt 0 ]; then

--- a/internal/assets/apply-nftables.sh
+++ b/internal/assets/apply-nftables.sh
@@ -108,6 +108,23 @@ if [ -n "$TARGET_CGROUP" ] && [ -n "$LEASH_PORT" ]; then
     fi
 fi
 
+# Degraded mode (#67): no target cgroup (e.g. Docker Desktop Kubernetes private
+# cgroup namespace). The control plane must still be isolated, so block ALL local
+# access to the port — the same namespace-wide boundary as the cgroup fallback above.
+if [ -z "$TARGET_CGROUP" ] && [ -n "$LEASH_PORT" ]; then
+    ensure_chain inet leash out_filter { type filter hook output priority 0\; }
+    echo "leash: WARNING: no target cgroup (degraded mode); blocking all local access to control plane port $LEASH_PORT" >&2
+    if nft_cmd list chain inet leash out_filter 2>/dev/null | grep -F "leash:block-control-plane-fallback" >/dev/null; then
+        : # Rule already exists, nothing to do
+    elif ensure_rule inet leash out_filter "leash:block-control-plane-fallback" tcp dport $LEASH_PORT reject with tcp reset; then
+        echo "leash: blocked local access to control plane port $LEASH_PORT (degraded, no cgroup)"
+    else
+        echo "leash: FATAL: could not apply control plane isolation (degraded mode)" >&2
+        echo "leash: This security control is required to prevent target container from accessing leashd API" >&2
+        exit 1
+    fi
+fi
+
 # Report summary and exit successfully even if some rules failed
 if [ "$RULE_ERRORS" -gt 0 ]; then
     echo "leash: WARNING: $RULE_ERRORS nftables rule(s) failed to apply (network interception may be incomplete)" >&2

--- a/internal/leashd/runtime.go
+++ b/internal/leashd/runtime.go
@@ -256,18 +256,25 @@ func preFlight(cfg *runtimeConfig) error {
 	}
 
 	if strings.TrimSpace(cfg.CgroupPath) == "" {
-		return fmt.Errorf("cgroup path required (set --cgroup)")
-	}
-	info, err := os.Stat(cfg.CgroupPath)
-	if err != nil {
-		return fmt.Errorf("invalid cgroup path %q: %w", cfg.CgroupPath, err)
-	}
-	if !info.IsDir() {
-		return fmt.Errorf("invalid cgroup path %q: not a directory", cfg.CgroupPath)
-	}
-	controllersPath := filepath.Join(cfg.CgroupPath, "cgroup.controllers")
-	if _, err := os.Stat(controllersPath); err != nil {
-		return fmt.Errorf("invalid cgroup path %q: %v", cfg.CgroupPath, err)
+		// Degraded mode: no scopable cgroup (e.g. Docker Desktop Kubernetes, where
+		// the container's private cgroup namespace reports "0::/"). Rather than
+		// failing to start, run proxy-only: kernel BPF-LSM enforcement is disabled
+		// but the MITM proxy still enforces L7 policy, and the control-plane block
+		// falls back to a namespace-wide rule. Mirrors the cgroup-unavailable
+		// network fallback (#66). See issue #67.
+		log.Println("leash: WARNING: no cgroup path; running in degraded proxy-only mode — kernel LSM enforcement (file/exec/connect) disabled, L7 proxy enforcement remains active")
+	} else {
+		info, err := os.Stat(cfg.CgroupPath)
+		if err != nil {
+			return fmt.Errorf("invalid cgroup path %q: %w", cfg.CgroupPath, err)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("invalid cgroup path %q: not a directory", cfg.CgroupPath)
+		}
+		controllersPath := filepath.Join(cfg.CgroupPath, "cgroup.controllers")
+		if _, err := os.Stat(controllersPath); err != nil {
+			return fmt.Errorf("invalid cgroup path %q: %v", cfg.CgroupPath, err)
+		}
 	}
 
 	logPath := strings.TrimSpace(cfg.LogPath)
@@ -308,7 +315,7 @@ func preFlight(cfg *runtimeConfig) error {
 	if privateDir == "" {
 		return fmt.Errorf("LEASH_PRIVATE_DIR environment variable is required")
 	}
-	info, err = os.Stat(privateDir)
+	info, err := os.Stat(privateDir)
 	if err != nil {
 		return fmt.Errorf("validate LEASH_PRIVATE_DIR %q: %w", privateDir, err)
 	}

--- a/internal/leashd/runtime_degraded_test.go
+++ b/internal/leashd/runtime_degraded_test.go
@@ -1,0 +1,20 @@
+package leashd
+
+import "testing"
+
+// preFlight must allow startup when no cgroup path is available (degraded,
+// proxy-only mode) instead of failing with "cgroup path required". This is the
+// Docker Desktop Kubernetes case where /proc/self/cgroup reports "0::/" and
+// leash-entry cannot emit a scopable cgroup path. A non-empty-but-invalid
+// cgroup path is still rejected (covered by TestPreFlightInvalidCgroup).
+// See issue #67.
+func TestPreFlightAllowsMissingCgroup(t *testing.T) {
+	cfg, cleanup := setupRuntimeEnv(t, false)
+	defer cleanup()
+
+	cfg.CgroupPath = "" // degraded: no scopable cgroup
+
+	if err := preFlight(cfg); err != nil {
+		t.Fatalf("missing cgroup should be allowed (degraded proxy-only mode), got: %v", err)
+	}
+}

--- a/internal/lsm/manager.go
+++ b/internal/lsm/manager.go
@@ -158,6 +158,14 @@ func (m *LSMManager) UpdateRuntimeRules(policies *PolicySet) error {
 	m.reloadMutex.Lock()
 	defer m.reloadMutex.Unlock()
 
+	if m.cgroupPath == "" {
+		// Degraded mode: without a scopable cgroup we cannot attach cgroup-scoped
+		// BPF-LSM programs (they would govern the whole host, not the target).
+		// Skip kernel enforcement entirely; the proxy layer still enforces L7
+		// policy. See internal/leashd/runtime.go preFlight and issue #67.
+		return nil
+	}
+
 	if err := m.updateOpenLSM(policies); err != nil {
 		return err
 	}

--- a/internal/lsm/manager_degraded_test.go
+++ b/internal/lsm/manager_degraded_test.go
@@ -1,0 +1,23 @@
+package lsm
+
+import "testing"
+
+// In degraded mode the LSM manager has no scopable cgroup (e.g. Docker Desktop
+// Kubernetes, where the container's private cgroup namespace reports "0::/").
+// It must skip kernel enforcement entirely rather than attempt to attach
+// cgroup-scoped BPF programs (which would either fail to load or govern the
+// whole host). See issue #67.
+func TestUpdateRuntimeRulesSkippedWithoutCgroup(t *testing.T) {
+	m := NewLSMManager("", nil)
+
+	// A non-empty policy set: without the degraded-mode guard this would drive
+	// updateOpenLSM into a real BPF attach.
+	policies := &PolicySet{Open: []PolicyRule{{}}}
+	if !policies.HasOpenPolicies() {
+		t.Fatal("test setup: expected open policies")
+	}
+
+	if err := m.UpdateRuntimeRules(policies); err != nil {
+		t.Fatalf("empty cgroup should skip LSM attach and return nil, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

On Docker Desktop with Kubernetes the agent container runs in a private cgroup namespace where `/proc/self/cgroup` reports `0::/`. `leash-entry`'s `emitCgroupPath()` skips `/` as invalid, so `/leash/cgroup-path` is never written, and `leashd` then FATALs at startup with `cgroup path required (set --cgroup)` — before any enforcement starts.

This is separate from #66 (which fixed the `xt_cgroup` network path): even with that fix, leashd can't start on Docker Desktop K8s because **cgroup-path discovery fails first**.

This change makes leash **degrade gracefully** instead of failing, following the same philosophy as #66 (*cgroup unavailable → fall back + WARNING, never FATAL, preserve the boundary*):

- **`cmd/leash-entry/main.go`** — when no scopable cgroup is found, log a `WARNING` and continue (don't abort the container) so leashd can start.
- **`internal/leashd/runtime.go`** — `preFlight` allows an empty cgroup path (proxy-only, warns); a non-empty path is still validated as before.
- **`internal/lsm/manager.go`** — `UpdateRuntimeRules` no-ops when there is no cgroup, so no cgroup-scoped BPF-LSM programs are attached (they'd have nothing valid to scope to).
- **`internal/assets/apply-{iptables,ip6tables,nftables}.sh`** — when there is no target cgroup, still isolate the control plane with a **namespace-wide** block (the same boundary as the existing #66 cgroup fallback), so degraded mode stays safe.

**Net:** the kernel LSM layer (file/exec/connect) is disabled when the cgroup is undiscoverable, but the **L7 MITM proxy** (hostname/header/MCP) keeps enforcing and the control plane stays isolated — defense-in-depth minus the kernel layer, with a clear warning, rather than a hard failure.

## Design note

This follows #66's pattern: automatic fallback + `WARNING`, no new flag. Since degraded mode is a reduction in enforcement, I'm happy to instead gate it behind an explicit opt-in flag (e.g. `--allow-no-cgroup`) if you'd prefer that posture.

## Validation

- `go build` + `go vet` clean for `internal/lsm`, `internal/leashd`, `cmd/leash-entry`.
- New unit tests pass: LSM-manager no-op without a cgroup; `preFlight` allows a missing cgroup. All 14 existing `preFlight` tests still pass (non-empty invalid cgroup is still rejected).
- `sh -n` clean on all three netfilter scripts.
- **Not yet validated end-to-end on Docker Desktop Kubernetes** (no access to that environment). Would appreciate maintainer/CI verification there, plus a no-regression check on bare Linux. Happy to iterate.

Closes #67
